### PR TITLE
Fixed the potentially uncontrolled problem of TextArea

### DIFF
--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -56,7 +56,7 @@ export const TextArea = UUI.FunctionComponent({
         placeholder={props.placeholder}
         disabled={props.disabled}
         maxLength={props.maxLength}
-        value={props.value === undefined ? undefined : (props.value || undefined)}
+        value={props.value === undefined ? undefined : (props.value || '')}
         onChange={props.onChange === undefined ? undefined : (
           (event) => {
             props.onChange && props.onChange(event.target.value, event)


### PR DESCRIPTION
The property `value` of the component TextArea is potentially `undefined` when a `value` of `''` is passed to this component, which causes the `controlled to uncontrolled component` or `uncontrolled to controlled component` warning.

Fixed by using `''` as the fallback. 🙌