### PR TITLE
fix:use min-height

### DIFF
--- a/src/styles/components/Tag.scss
+++ b/src/styles/components/Tag.scss
@@ -5,7 +5,7 @@
   align-items: center;
   align-content: center;
   background-color: #718096;
-  height: 32px;
+  min-height: 32px;
   padding: 0 0.5rem;
   border-radius: 0.25rem;
 


### PR DESCRIPTION
when using Tag component custom style.
use extendChildrenAfter the element will overflow the container.
like  https://doc.uui.cool/?path=/story/%E7%BB%84%E4%BB%B6-%E6%A0%87%E7%AD%BE-tag--custom-style-1
I think `min-height` instead of `height` can fix it.